### PR TITLE
Update GitHub email visibility failure message

### DIFF
--- a/extensions/oic_login.py
+++ b/extensions/oic_login.py
@@ -314,7 +314,8 @@ class OICAuthResp(Action, OICMixin):
         if github_email is None:
             raise ValueError(
                 'Your email address couldn\'t be fetched from your GitHub '
-                'profile. Please make it public at https://github.com/settings/emails.'
+                'profile. Please make it public in the "Public email" section of '
+                'https://github.com/settings/profile.'
             )
 
         users = self.db.user.filter(None, {'address': github_email})


### PR DESCRIPTION
The previous link didn't contain the option necessary to make the email public. While the email settings page may need to be edited as well, the current github UI contains a pointer from the newly linked "Public email" section to the email settings page so users should be better guided to do the right update.