### PR TITLE
Update guess_version function for traceback links

### DIFF
--- a/extensions/local_replace.py
+++ b/extensions/local_replace.py
@@ -42,16 +42,13 @@ def make_file_link(match):
 
 def guess_version(path):
     """Search for Python version hints in the file path."""
-    match = re.search(r'((?<=[Pp]ython)[23]\d|[23]\.\d)', path)
+    match = re.search(r'((?<=[Pp]ython)[23]\d\d?|[23]\.\d\d?)', path)
     if not match:
-        return 'master'
+        return 'main'
     version = match.group(1)
     if '.' not in version:
-        version = '.'.join(version)
-    if version in ['2.3', '2.4', '2.5', '2.6', '2.7', '3.1', '3.2',
-                   '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9']:
-        return version
-    return 'master'
+        version = '.'.join((version[0], version[1:]))
+    return version
 
 
 def make_traceback_link(match):


### PR DESCRIPTION
s/master/main/, and add support for double-digit minor versions.

This also removes the check for specific version numbers.  This may open
us up to creating some bad links, (2.8, anyone?) but chances are that
any link we make in such cases would be a bad one anyway.  We are still
restricted to 2.x and 3.x, though.

Closes python/bugs.python.org#61
