### PR TITLE
Fix experts list URL after branch rename

### DIFF
--- a/extensions/jnosy.py
+++ b/extensions/jnosy.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     import simplejson as json
 
-url = 'https://raw.githubusercontent.com/python/devguide/master/experts.rst'
+url = 'https://raw.githubusercontent.com/python/devguide/main/experts.rst'
 
 # possible states
 no_table = 0  # not parsing a table


### PR DESCRIPTION
NB: This should not be merged until after python/devguide has renamed the `master` branch to `main` (python/devguide#689).
