### PR TITLE
Add a bpo -> GitHub redirect action.

### DIFF
--- a/extensions/pydevutils.py
+++ b/extensions/pydevutils.py
@@ -106,14 +106,17 @@ class RandomIssueAction(Action):
 class Redirect2GitHubAction(Action):
     def handle(self):
         """Redirect to the corresponding GitHub issue."""
-        # pass the bpo id as issue?@action=redirect&bpo=ID
+        # This action is invoked by opening /issue?@action=redirect&bpo=ID
+        # If ID is a valid bpo issue ID linked to its corresponding GitHub
+        # issue, the action will automatically redirect the browser to the
+        # GitHub issue, if not, it will show an error message.
         issue = self.context['context']
         request = self.context['request']
         bpo_id = request.form.getvalue('bpo')
         if not bpo_id:
             return 'Please provide a bpo issue id with `&bpo=ID` in the URL.'
         try:
-            bpo_id = int(bpo_id)
+            bpo_id = int(bpo_id)  # make sure it's just a number
         except ValueError:
             return 'Please provide a valid bpo issue id.'
         try:

--- a/extensions/pydevutils.py
+++ b/extensions/pydevutils.py
@@ -103,6 +103,29 @@ class RandomIssueAction(Action):
         raise Redirect(url)
 
 
+class Redirect2GitHubAction(Action):
+    def handle(self):
+        """Redirect to the corresponding GitHub issue."""
+        # pass the bpo id as issue?@action=redirect&bpo=ID
+        issue = self.context['context']
+        request = self.context['request']
+        bpo_id = request.form.getvalue('bpo')
+        if not bpo_id:
+            return 'Please provide a bpo issue id with `&bpo=ID` in the URL.'
+        try:
+            bpo_id = int(bpo_id)
+        except ValueError:
+            return 'Please provide a valid bpo issue id.'
+        try:
+            gh_id = issue._klass.get(bpo_id, 'github')
+        except IndexError:
+            return 'There is no bpo issue with id {}.'.format(bpo_id)
+        if not gh_id:
+            return 'There is no GitHub id for bpo-{}.'.format(bpo_id)
+        url = 'https://www.github.com/python/cpython/issues/{}'.format(gh_id)
+        raise Redirect(url)
+
+
 def openid_links(request):
     providers = [
         ('Google', 'oic_login', 'https://www.google.com/favicon.ico'),
@@ -129,4 +152,5 @@ def init(instance):
                           issueid_and_action_from_class)
     instance.registerUtil('clas_as_json', clas_as_json)
     instance.registerAction('random', RandomIssueAction)
+    instance.registerAction('redirect', Redirect2GitHubAction)
     instance.registerUtil('openid_links', openid_links)

--- a/schema.py
+++ b/schema.py
@@ -202,7 +202,8 @@ issue = IssueClass(db, "issue",
                    nosy_count=Number(),
                    message_count=Number(),
                    hgrepos=Multilink('hgrepo'),
-                   pull_requests=Multilink('pull_request'))
+                   pull_requests=Multilink('pull_request'),
+                   github=String())
 
 #
 # TRACKER SECURITY SETTINGS

--- a/schema.py
+++ b/schema.py
@@ -203,7 +203,7 @@ issue = IssueClass(db, "issue",
                    message_count=Number(),
                    hgrepos=Multilink('hgrepo'),
                    pull_requests=Multilink('pull_request'),
-                   github=String())
+                   github=Integer())
 
 #
 # TRACKER SECURITY SETTINGS


### PR DESCRIPTION
This PR adds an action that, given a bpo id, redirects to the corresponding GitHub issue.  It also adds a new `github` attribute to the `Issue` class where the GitHub id will be stored.  This field will be populated after the migration happened.  This PR can already be merged before the deployment.

See also psf/gh-migration#17.