### PR TITLE
Make bpo read-only

### DIFF
--- a/html/page.html
+++ b/html/page.html
@@ -278,9 +278,9 @@ status_all string:-1,1,2,3;
     </div>
     <p>This issue tracker <b>is being migrated to GitHub</b>, and is currently <b>read-only</b>.<br />
     During the migration it is not possible to create issues, edit them, or add comments.<br />
-    For more information, <a title="Github Issues Migration is coming soon"
-    href="https://discuss.python.org/t/github-issues-migration-is-coming-soon/13791">
-    see this post about the migration.</a>
+    For more information, <a title="Github Issues Migration: status update"
+    href="https://discuss.python.org/t/github-issues-migration-status-update/14573">
+    see this post about the status of the migration.</a>
     </p>
 </div>
  <p tal:condition="options/error_message | nothing" class="error-message"

--- a/html/page.html
+++ b/html/page.html
@@ -278,7 +278,7 @@ status_all string:-1,1,2,3;
     </div>
     <p>This issue tracker <b>is being migrated to GitHub</b>, and is currently <b>read-only</b>.<br />
     During the migration it is not possible to create issues, edit them, or add comments.<br />
-    For more information, <a title="Github Issues Migration: status update"
+    For more information, <a title="GitHub Issues Migration: status update"
     href="https://discuss.python.org/t/github-issues-migration-status-update/14573">
     see this post about the status of the migration.</a>
     </p>

--- a/html/page.html
+++ b/html/page.html
@@ -276,12 +276,8 @@ status_all string:-1,1,2,3;
         ➜
         <img width="32" src="@@file/gh-icon.png" />
     </div>
-    <p>This issue tracker will soon become read-only and move to GitHub.<br />
-    For a smoother transition, remember to
-    <tal:block tal:condition="python:request.user.username == 'anonymous'">
-        log in and link your GitHub username to your profile.</tal:block>
-    <tal:block tal:condition="python:request.user.username != 'anonymous'">
-        link your GitHub username to <a tal:attributes="href string:user${request/user/id}">your profile</a>.</tal:block><br />
+    <p>This issue tracker <b>is being migrated to GitHub</b>, and is currently <b>read-only</b>.<br />
+    During the migration it is not possible to create issues, edit them, or add comments.<br />
     For more information, <a title="Github Issues Migration is coming soon"
     href="https://discuss.python.org/t/github-issues-migration-is-coming-soon/13791">
     see this post about the migration.</a>

--- a/html/style.css
+++ b/html/style.css
@@ -620,6 +620,7 @@ li#menu-shortcuts-help span {
 
 #migration-notice {
     background-color: #e0e0e0;
+    border: 2px solid red;
     margin-bottom: 1em;
     display: flex;
     align-items: center;

--- a/schema.py
+++ b/schema.py
@@ -8,6 +8,10 @@
 #   creator = Link('user')
 #   actor = Link('user')
 
+# NOTE: this tracker is now read-only.
+# Coordinators can still edit fields, and users can still edit their profiles.
+# All the related changes are marked with a 'read-only' note.
+
 # Issue Type
 issue_type = Class(db, 'issue_type',
                    name=String(),
@@ -100,8 +104,9 @@ user = Class(db, "user",
              github=String(),
              )
 user.setkey("username")
-db.security.addPermission(name='Register', klass='user',
-                          description='User is allowed to register new user')
+# read-only: registration is no longer allowed
+# db.security.addPermission(name='Register', klass='user',
+#                           description='User is allowed to register new user')
 
 openid_discovery = Class(db, 'openid_discovery',
                          url=String(), # key
@@ -235,19 +240,20 @@ for cl in ('issue_type', 'severity', 'component',
     db.security.addPermissionToRole('User', 'View', cl)
     db.security.addPermissionToRole('Anonymous', 'View', cl)
 
-def may_edit_hgrepo(db, userid, itemid):
-    return userid == db.hgrepo.get(itemid, "creator")
-db.security.addPermissionToRole('User', 'Create', 'hgrepo')
-p = db.security.addPermission(name='Edit', klass='hgrepo', check=may_edit_hgrepo,
-                              properties=['url', 'patchbranch'])
-db.security.addPermissionToRole('User', p)
-
-def may_edit_pull_request(db, userid, itemid):
-    return userid == db.pull_request.get(itemid, "creator")
-db.security.addPermissionToRole('User', 'Create', 'pull_request')
-p = db.security.addPermission(name='Edit', klass='pull_request',
-                              check=may_edit_pull_request, properties=['number', 'title'])
-db.security.addPermissionToRole('User', p)
+# read-only: users can't create or edit HG repos or PRs
+# def may_edit_hgrepo(db, userid, itemid):
+#     return userid == db.hgrepo.get(itemid, "creator")
+# db.security.addPermissionToRole('User', 'Create', 'hgrepo')
+# p = db.security.addPermission(name='Edit', klass='hgrepo', check=may_edit_hgrepo,
+#                               properties=['url', 'patchbranch'])
+# db.security.addPermissionToRole('User', p)
+#
+# def may_edit_pull_request(db, userid, itemid):
+#     return userid == db.pull_request.get(itemid, "creator")
+# db.security.addPermissionToRole('User', 'Create', 'pull_request')
+# p = db.security.addPermission(name='Edit', klass='pull_request',
+#                               check=may_edit_pull_request, properties=['number', 'title'])
+# db.security.addPermissionToRole('User', p)
 
 def may_view_spam(cl):
     klassname = cl
@@ -285,7 +291,8 @@ for cl in ('file', 'msg'):
     db.security.addPermissionToRole('Anonymous', p)
     db.security.addPermissionToRole('User', p)
 
-    db.security.addPermissionToRole('User', 'Create', cl)
+    # read-only: users can't reply to issues or attach files
+    # db.security.addPermissionToRole('User', 'Create', cl)
 
     p = db.security.addPermission(name='View', klass=cl,
                                   description="Allowed to see content of object regardless of spam status",
@@ -300,36 +307,37 @@ for cl in ('file', 'msg'):
 
     db.security.addPermissionToRole('Anonymous', spamcheck)
 
-def may_edit_file(db, userid, itemid):
-    return userid == db.file.get(itemid, "creator")
-p = db.security.addPermission(name='Edit', klass='file', check=may_edit_file,
-    description="User is allowed to remove their own files")
-db.security.addPermissionToRole('User', p)
+# read-only: users can't edit these things anymore
+# def may_edit_file(db, userid, itemid):
+#     return userid == db.file.get(itemid, "creator")
+# p = db.security.addPermission(name='Edit', klass='file', check=may_edit_file,
+#     description="User is allowed to remove their own files")
+# db.security.addPermissionToRole('User', p)
 
-p = db.security.addPermission(name='Create', klass='issue',
-                              properties=('title', 'type',
-                                          'components', 'versions',
-                                          'severity',
-                                          'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
-                              description='User can report and discuss issues')
-db.security.addPermissionToRole('User', p)
+# p = db.security.addPermission(name='Create', klass='issue',
+#                               properties=('title', 'type',
+#                                           'components', 'versions',
+#                                           'severity',
+#                                           'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
+#                               description='User can report and discuss issues')
+# db.security.addPermissionToRole('User', p)
 
-p = db.security.addPermission(name='Edit', klass='issue',
-                              properties=('title', 'type',
-                                          'components', 'versions',
-                                          'severity',
-                                          'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
-                              description='User can report and discuss issues')
-db.security.addPermissionToRole('User', p)
+# p = db.security.addPermission(name='Edit', klass='issue',
+#                               properties=('title', 'type',
+#                                           'components', 'versions',
+#                                           'severity',
+#                                           'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
+#                               description='User can report and discuss issues')
+# db.security.addPermissionToRole('User', p)
 
 # Allow users to close issues they created
-def close_own_issue(db, userid, itemid):
-    return userid == db.issue.get(itemid, 'creator')
-p = db.security.addPermission(name='Edit', klass='issue',
-                              properties=('status', 'resolution'),
-                              description='User can close issues he created',
-                              check=close_own_issue)
-db.security.addPermissionToRole('User', p)
+# def close_own_issue(db, userid, itemid):
+#     return userid == db.issue.get(itemid, 'creator')
+# p = db.security.addPermission(name='Edit', klass='issue',
+#                               properties=('status', 'resolution'),
+#                               description='User can close issues he created',
+#                               check=close_own_issue)
+# db.security.addPermissionToRole('User', p)
 
 db.security.addPermissionToRole('User', 'SB: May Report Misclassified')
 
@@ -343,9 +351,10 @@ for cl in ('issue_type', 'severity', 'component',
            'issue', 'file', 'msg', 'keyword', 'pull_request'):
     db.security.addPermissionToRole('Developer', 'View', cl)
 
-for cl in ('issue', 'file', 'msg', 'keyword', 'pull_request'):
-    db.security.addPermissionToRole('Developer', 'Edit', cl)
-    db.security.addPermissionToRole('Developer', 'Create', cl)
+# read-only: developers can't edit these classes anymore
+# for cl in ('issue', 'file', 'msg', 'keyword', 'pull_request'):
+#     db.security.addPermissionToRole('Developer', 'Edit', cl)
+#     db.security.addPermissionToRole('Developer', 'Create', cl)
 
 
 ##########################
@@ -410,6 +419,7 @@ p = db.security.addPermission(name='Edit', klass='user', check=own_record,
                 'homepage', 'github'))
                 # Note: 'roles' excluded - users should not be able to edit their own roles.
                 # Also excluded: contrib_form, contrib_form_date, iscommitter
+                # read-only: users can still edit their info
 for r in 'User', 'Developer':
     db.security.addPermissionToRole(r, p)
 
@@ -471,7 +481,8 @@ db.security.addPermissionToRole('Anonymous', 'Web Access')
 # Assign the appropriate permissions to the anonymous user's Anonymous
 # Role. Choices here are:
 # - Allow anonymous users to register
-db.security.addPermissionToRole('Anonymous', 'Register', 'user')
+# read-only: new accounts can't be created anymore
+# db.security.addPermissionToRole('Anonymous', 'Register', 'user')
 
 # Allow anonymous users access to view issues (and the related, linked
 # information).


### PR DESCRIPTION
This PR makes bpo read-only for `User`s and `Developer`s, while leaving write access to `Coordinator`s.

**It should be merged when the migration starts.**

Users can still log in and edit their profile, but they can't create or comment on issues.  New accounts can't be created.  Since the permissions are handled at the schema level, even if I missed something, it should still be impossible to edit issues.  In those cases bpo might give a not-particularly-user-friendly error, but those can be tested and improved later.

See also psf/gh-migration#14.