### PR TITLE
Add links from bpo to GitHub

### DIFF
--- a/html/home.html
+++ b/html/home.html
@@ -6,5 +6,5 @@
 -->
 <span tal:replace="structure python:db.issue.renderWith('index',
     sort=[('-', 'activity')], filter=['status'],
-    columns=['id', 'activity', 'title', 'creator', 'assignee', 'status', 'type', 'message_count'],
+    columns=['id', 'github', 'activity', 'title', 'creator', 'assignee', 'status', 'type', 'message_count'],
     filterspec={'status':['1','3']})" />

--- a/html/issue.index.html
+++ b/html/issue.index.html
@@ -25,6 +25,7 @@
   <tr>
    <th tal:condition="request/show/severity" i18n:translate="">Severity</th>
    <th tal:condition="request/show/id" i18n:translate="">ID</th>
+   <th tal:condition="request/show/github" title="GitHub ID" i18n:translate="">GH</th>
    <th tal:condition="request/show/creation" i18n:translate="">Creation</th>
    <th tal:condition="request/show/activity" i18n:translate="">Activity</th>
    <th tal:condition="request/show/actor" i18n:translate="">Actor</th>
@@ -56,6 +57,10 @@
    <td tal:condition="request/show/severity"
        tal:content="python:i.severity.plain() or default">&nbsp;</td>
    <td tal:condition="request/show/id" tal:content="i/id">&nbsp;</td>
+   <td tal:condition="request/show/github">
+    <a tal:attributes="href string:https://github.com/python/cpython/issues/${i/github}"
+		tal:content="python:str(i.github) or '-'">GH ID</a>
+   </td>
    <td class="date" tal:condition="request/show/creation"
        tal:content="i/creation/reldate">&nbsp;</td>
    <td class="date" tal:condition="request/show/activity"

--- a/html/issue.item.html
+++ b/html/issue.item.html
@@ -46,6 +46,17 @@
       onSubmit="return submit_once()" enctype="multipart/form-data"
       tal:attributes="action context/designator">
 
+<div tal:condition="context/github" id="gh-issue-link">
+    <a tal:define="gh_url string:https://github.com/python/cpython/issues/${context/github}"
+       tal:attributes="href gh_url">
+        <img width="32" src="@@file/gh-icon.png" />
+        <p>
+            <span>This issue has been migrated to GitHub:</span>
+            <tal:block tal:replace="gh_url" />
+        </p>
+    </a>
+</div>
+
 <fieldset><legend>classification</legend>
 <table class="form">
 <tr>

--- a/html/issue.search.html
+++ b/html/issue.search.html
@@ -9,7 +9,7 @@
       tal:attributes="action request/classname">
 
 <table class="form" tal:define="
-   cols python:request.columns or 'id activity title status assignedto'.split();
+   cols python:request.columns or 'id github activity title status assignedto'.split();
    sort_on python:request.sort and request.sort[0] or nothing;
    sort_desc python:sort_on and sort_on[0] == '-' or '-';
    sort_on python:(sort_on and sort_on[1]) or (not request.nodeid and 'activity') or '';
@@ -62,6 +62,13 @@
 
 <tr tal:define="name string:id">
   <th i18n:translate="">ID:</th>
+  <td metal:use-macro="search_input"></td>
+  <td metal:use-macro="column_input"></td>
+  <td metal:use-macro="sort_input"></td>
+  <td>&nbsp;</td>
+</tr>
+<tr tal:define="name string:github">
+  <th i18n:translate="">GitHub ID:</th>
   <td metal:use-macro="search_input"></td>
   <td metal:use-macro="column_input"></td>
   <td metal:use-macro="sort_input"></td>

--- a/html/page.html
+++ b/html/page.html
@@ -19,8 +19,8 @@
 <body
 tal:define="
 kw_create python:request.user.hasPermission('Create', 'keyword');
-columns string:id,activity,title,creator,status;
-columns_showall string:id,activity,title,creator,assignee,status,type;
+columns string:id,github,activity,title,creator,status;
+columns_showall string:id,github,activity,title,creator,assignee,status,type;
 status_notresolved string:-1,1,3;
 status_all string:-1,1,2,3;
 ">
@@ -103,7 +103,7 @@ status_all string:-1,1,2,3;
                   '@sort': '-activity',
                   '@group': 'status',
                   '@filter': 'creator',
-                  '@columns': 'id,activity,title,status',
+                  '@columns': 'id,github,activity,title,status',
                   '@search_text': '',
                   'creator': request.user.id,
                   '@dispname': i18n.gettext('Created by you'),
@@ -118,7 +118,7 @@ status_all string:-1,1,2,3;
                   '@sort': '-activity',
                   '@group': 'status',
                   '@filter': 'nosy',
-                  '@columns': 'id,activity,title,status,creator',
+                  '@columns': 'id,github,activity,title,status,creator',
                   '@search_text': '',
                   'nosy': request.user.id,
                   '@dispname': i18n.gettext('Followed by you'),
@@ -134,7 +134,7 @@ status_all string:-1,1,2,3;
                   '@sort': '-activity',
                   '@group': 'status',
                   '@filter': 'assignee',
-                  '@columns': 'id,activity,title,creator,status',
+                  '@columns': 'id,github,activity,title,creator,status',
                   '@search_text': '',
                   'assignee': request.user.id,
                   '@dispname': i18n.gettext('Assigned to you'),

--- a/html/page.html
+++ b/html/page.html
@@ -276,12 +276,8 @@ status_all string:-1,1,2,3;
         ➜
         <img width="32" src="@@file/gh-icon.png" />
     </div>
-    <p>This issue tracker will soon become read-only and move to GitHub.<br />
-    For a smoother transition, remember to
-    <tal:block tal:condition="python:request.user.username == 'anonymous'">
-        log in and link your GitHub username to your profile.</tal:block>
-    <tal:block tal:condition="python:request.user.username != 'anonymous'">
-        link your GitHub username to <a tal:attributes="href string:user${request/user/id}">your profile</a>.</tal:block><br />
+    <p>This issue tracker <b>is being migrated to GitHub</b>, and is currently <b>read-only</b>.<br />
+    During the migration it is not possible to create issues, edit them, or add comments.<br />
     For more information, <a title="Github Issues Migration is coming soon"
     href="https://discuss.python.org/t/github-issues-migration-is-coming-soon/13791">
     see this post about the migration.</a>

--- a/html/style.css
+++ b/html/style.css
@@ -620,6 +620,7 @@ li#menu-shortcuts-help span {
 
 #migration-notice {
     background-color: #e0e0e0;
+    border: 2px solid red;
     margin-bottom: 1em;
     display: flex;
     align-items: center;

--- a/html/style.css
+++ b/html/style.css
@@ -633,6 +633,23 @@ li#menu-shortcuts-help span {
     column-gap: .5em;
 }
 
+#gh-issue-link {
+    background-color: #e0e0e0;
+    margin-bottom: 1em;
+}
+#gh-issue-link a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    column-gap: .5em;
+}
+#gh-issue-link span {
+    display: block;
+}
+#gh-issue-link a:not(:hover) span {
+    color: black;
+}
+
 /* styles for printing */
 @media print {
 

--- a/schema.py
+++ b/schema.py
@@ -8,6 +8,10 @@
 #   creator = Link('user')
 #   actor = Link('user')
 
+# NOTE: this tracker is now read-only.
+# Coordinators can still edit fields, and users can still edit their profiles.
+# All the related changes are marked with a 'read-only' note.
+
 # Issue Type
 issue_type = Class(db, 'issue_type',
                    name=String(),
@@ -100,8 +104,9 @@ user = Class(db, "user",
              github=String(),
              )
 user.setkey("username")
-db.security.addPermission(name='Register', klass='user',
-                          description='User is allowed to register new user')
+# read-only: registration is no longer allowed
+# db.security.addPermission(name='Register', klass='user',
+#                           description='User is allowed to register new user')
 
 openid_discovery = Class(db, 'openid_discovery',
                          url=String(), # key
@@ -235,19 +240,20 @@ for cl in ('issue_type', 'severity', 'component',
     db.security.addPermissionToRole('User', 'View', cl)
     db.security.addPermissionToRole('Anonymous', 'View', cl)
 
-def may_edit_hgrepo(db, userid, itemid):
-    return userid == db.hgrepo.get(itemid, "creator")
-db.security.addPermissionToRole('User', 'Create', 'hgrepo')
-p = db.security.addPermission(name='Edit', klass='hgrepo', check=may_edit_hgrepo,
-                              properties=['url', 'patchbranch'])
-db.security.addPermissionToRole('User', p)
-
-def may_edit_pull_request(db, userid, itemid):
-    return userid == db.pull_request.get(itemid, "creator")
-db.security.addPermissionToRole('User', 'Create', 'pull_request')
-p = db.security.addPermission(name='Edit', klass='pull_request',
-                              check=may_edit_pull_request, properties=['number', 'title'])
-db.security.addPermissionToRole('User', p)
+# read-only: users can't create or edit HG repos or PRs
+# def may_edit_hgrepo(db, userid, itemid):
+#     return userid == db.hgrepo.get(itemid, "creator")
+# db.security.addPermissionToRole('User', 'Create', 'hgrepo')
+# p = db.security.addPermission(name='Edit', klass='hgrepo', check=may_edit_hgrepo,
+#                               properties=['url', 'patchbranch'])
+# db.security.addPermissionToRole('User', p)
+#
+# def may_edit_pull_request(db, userid, itemid):
+#     return userid == db.pull_request.get(itemid, "creator")
+# db.security.addPermissionToRole('User', 'Create', 'pull_request')
+# p = db.security.addPermission(name='Edit', klass='pull_request',
+#                               check=may_edit_pull_request, properties=['number', 'title'])
+# db.security.addPermissionToRole('User', p)
 
 def may_view_spam(cl):
     klassname = cl
@@ -285,7 +291,8 @@ for cl in ('file', 'msg'):
     db.security.addPermissionToRole('Anonymous', p)
     db.security.addPermissionToRole('User', p)
 
-    db.security.addPermissionToRole('User', 'Create', cl)
+    # read-only: users can't reply to issues or attach files
+    # db.security.addPermissionToRole('User', 'Create', cl)
 
     p = db.security.addPermission(name='View', klass=cl,
                                   description="Allowed to see content of object regardless of spam status",
@@ -300,36 +307,37 @@ for cl in ('file', 'msg'):
 
     db.security.addPermissionToRole('Anonymous', spamcheck)
 
-def may_edit_file(db, userid, itemid):
-    return userid == db.file.get(itemid, "creator")
-p = db.security.addPermission(name='Edit', klass='file', check=may_edit_file,
-    description="User is allowed to remove their own files")
-db.security.addPermissionToRole('User', p)
+# read-only: users can't edit these things anymore
+# def may_edit_file(db, userid, itemid):
+#     return userid == db.file.get(itemid, "creator")
+# p = db.security.addPermission(name='Edit', klass='file', check=may_edit_file,
+#     description="User is allowed to remove their own files")
+# db.security.addPermissionToRole('User', p)
 
-p = db.security.addPermission(name='Create', klass='issue',
-                              properties=('title', 'type',
-                                          'components', 'versions',
-                                          'severity',
-                                          'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
-                              description='User can report and discuss issues')
-db.security.addPermissionToRole('User', p)
+# p = db.security.addPermission(name='Create', klass='issue',
+#                               properties=('title', 'type',
+#                                           'components', 'versions',
+#                                           'severity',
+#                                           'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
+#                               description='User can report and discuss issues')
+# db.security.addPermissionToRole('User', p)
 
-p = db.security.addPermission(name='Edit', klass='issue',
-                              properties=('title', 'type',
-                                          'components', 'versions',
-                                          'severity',
-                                          'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
-                              description='User can report and discuss issues')
-db.security.addPermissionToRole('User', p)
+# p = db.security.addPermission(name='Edit', klass='issue',
+#                               properties=('title', 'type',
+#                                           'components', 'versions',
+#                                           'severity',
+#                                           'messages', 'files', 'nosy', 'hgrepos', 'pull_requests'),
+#                               description='User can report and discuss issues')
+# db.security.addPermissionToRole('User', p)
 
 # Allow users to close issues they created
-def close_own_issue(db, userid, itemid):
-    return userid == db.issue.get(itemid, 'creator')
-p = db.security.addPermission(name='Edit', klass='issue',
-                              properties=('status', 'resolution'),
-                              description='User can close issues he created',
-                              check=close_own_issue)
-db.security.addPermissionToRole('User', p)
+# def close_own_issue(db, userid, itemid):
+#     return userid == db.issue.get(itemid, 'creator')
+# p = db.security.addPermission(name='Edit', klass='issue',
+#                               properties=('status', 'resolution'),
+#                               description='User can close issues he created',
+#                               check=close_own_issue)
+# db.security.addPermissionToRole('User', p)
 
 db.security.addPermissionToRole('User', 'SB: May Report Misclassified')
 
@@ -343,9 +351,10 @@ for cl in ('issue_type', 'severity', 'component',
            'issue', 'file', 'msg', 'keyword', 'pull_request'):
     db.security.addPermissionToRole('Developer', 'View', cl)
 
-for cl in ('issue', 'file', 'msg', 'keyword', 'pull_request'):
-    db.security.addPermissionToRole('Developer', 'Edit', cl)
-    db.security.addPermissionToRole('Developer', 'Create', cl)
+# read-only: developers can't edit these classes anymore
+# for cl in ('issue', 'file', 'msg', 'keyword', 'pull_request'):
+#     db.security.addPermissionToRole('Developer', 'Edit', cl)
+#     db.security.addPermissionToRole('Developer', 'Create', cl)
 
 
 ##########################
@@ -410,6 +419,7 @@ p = db.security.addPermission(name='Edit', klass='user', check=own_record,
                 'homepage', 'github'))
                 # Note: 'roles' excluded - users should not be able to edit their own roles.
                 # Also excluded: contrib_form, contrib_form_date, iscommitter
+                # read-only: users can still edit their info
 for r in 'User', 'Developer':
     db.security.addPermissionToRole(r, p)
 
@@ -471,7 +481,8 @@ db.security.addPermissionToRole('Anonymous', 'Web Access')
 # Assign the appropriate permissions to the anonymous user's Anonymous
 # Role. Choices here are:
 # - Allow anonymous users to register
-db.security.addPermissionToRole('Anonymous', 'Register', 'user')
+# read-only: new accounts can't be created anymore
+# db.security.addPermissionToRole('Anonymous', 'Register', 'user')
 
 # Allow anonymous users access to view issues (and the related, linked
 # information).


### PR DESCRIPTION
This PR adds links from bpo issues to the corresponding GH issues in two places:
* in a new GH ID column in the `issue.index.html` page
* in a banner in the `issue.item.html` page

This PR should be merged after the migration is completed and the GH IDs have been added to the DB, and before #12.

See also psf/gh-migration#15.