### PR TITLE
Skip an extra GitHub redirect

### DIFF
--- a/extensions/pydevutils.py
+++ b/extensions/pydevutils.py
@@ -125,14 +125,14 @@ class Redirect2GitHubAction(Action):
             return 'There is no bpo issue with id {}.'.format(bpo_id)
         if not gh_id:
             return 'There is no GitHub id for bpo-{}.'.format(bpo_id)
-        url = 'https://www.github.com/python/cpython/issues/{}'.format(gh_id)
+        url = 'https://github.com/python/cpython/issues/{}'.format(gh_id)
         raise Redirect(url)
 
 
 def openid_links(request):
     providers = [
         ('Google', 'oic_login', 'https://www.google.com/favicon.ico'),
-        ('GitHub', 'oic_login', 'https://www.github.com/favicon.ico'),
+        ('GitHub', 'oic_login', 'https://github.com/favicon.ico'),
         ('Launchpad', 'openid_login', 'https://launchpad.net/favicon.ico'),
     ]
     links = []


### PR DESCRIPTION
BPO URLs like https://bugs.python.org/issue?@action=redirect&bpo=44022 are HTTP 302 redirected to https://www.github.com/python/cpython/issues/88188 (with www) which are then HTTP 301 redirected to https://github.com/python/cpython/issues/88188 (no www):

![image](https://user-images.githubusercontent.com/1324225/231191342-3cf0609a-9683-449e-860b-6808c49820ee.png)

https://wheregoes.com/trace/20231739687/

Same thing for the favicon: https://wheregoes.com/trace/20231739705/

Let's skip that middle hop.
